### PR TITLE
feat(cli): addition of metadata manipulation sub commands

### DIFF
--- a/booru-cli/Cli/Commands/Metadata.hs
+++ b/booru-cli/Cli/Commands/Metadata.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
+-- yeah this is gonna be a bit of a fucking rant so buckle up,
+-- So.... you are telling me, out of fuckign nowhere,
+-- HASKELL HAS RECORD DOT SYNTAX???
+-- AJSDL KJASL:DK JAL:KSDJ :LKASJDL: AJSD ADSKL:J
+-- SOOOOOOOOOOO MUCH CODE THAT WOULD HAVE BEEEN MUUUUUUUCH NICER
+-- Hadd I fucking known this earlier
+-- FUCKING HELL
+
+module Cli.Commands.Metadata (meta) where
+
+import Booru.Core.Parsers (encode)
+import Booru.Schema.Identifier (extractId, extractId')
+import Booru.Schema.Images (Image (..), Images (..))
+import Cli.Options (CommonOpts (..), MetadataAction (..), MetadataOpts (..))
+import Cli.Commands.Build (build)
+import Cli.Utils.Common (getData)
+import Control.Monad (forM_)
+import Data.List (partition)
+
+meta :: MetadataOpts -> CommonOpts -> IO ()
+meta mo@MetadataOpts{action = a, resolvedNames = rnames} co@CommonOpts{dataDir = d} = do
+  (cachedImgs, datafile, _) <- getData d
+  let (reqImgs, otherImgs) = partition ((`elem` rnames) . resolvedName) cachedImgs
+  case a of
+    Get -> forM_ reqImgs displayMetadata
+    Update -> do
+      meta mo{action = Remove} co
+      build co
+    Remove -> do
+      forM_ reqImgs (\img -> putStrLn $ "Removing metadata of: " ++ extractId img.id)
+      writeFile datafile (show $ encode Images{images = otherImgs})
+
+displayMetadata :: Image -> IO ()
+displayMetadata img = do
+  putStrLn ""
+  putStrLn $ "provider: " ++ img.provider
+  putStrLn $ "id: " ++ unwords (extractId' img.id)
+  putStrLn $ "file: " ++ img.file
+  putStrLn $ "preview_file: " ++ img.preview_file
+  putStrLn $ "artists: " ++ unwords img.artists
+  putStrLn $ "characters: " ++ unwords img.characters
+  putStrLn $ "copyrights: " ++ unwords img.copyrights
+  putStrLn $ "rating: " ++ img.rating
+  putStrLn $ "tags: " ++ unwords img.tags

--- a/booru-cli/Cli/Dispatcher.hs
+++ b/booru-cli/Cli/Dispatcher.hs
@@ -3,6 +3,7 @@ module Cli.Dispatcher (dispatch) where
 import Cli.Commands.Build
 import Cli.Commands.Download
 import Cli.Commands.Generate
+import Cli.Commands.Metadata
 import Cli.Commands.Preview
 import Cli.Commands.Query
 import Cli.Options
@@ -13,6 +14,7 @@ dispatch Options{subcommand = sub, common = copts} =
   case sub of
     (Download opts) -> download opts
     (Query opts) -> query opts
+    (Metadata opts) -> meta opts
     Build -> build
     Preview -> preview
     GenConf -> generate

--- a/booru-cli/Cli/Options.hs
+++ b/booru-cli/Cli/Options.hs
@@ -4,6 +4,8 @@ module Cli.Options (
   CommonOpts (..),
   DownloadOpts (..),
   QueryOpts (..),
+  MetadataOpts (..),
+  MetadataAction (..),
   parseOpts,
 ) where
 
@@ -75,6 +77,7 @@ data Commands
   | Preview
   | Query QueryOpts
   | GenConf
+  | Metadata MetadataOpts
 
 -- | scaffolds logic for parsing sub commands
 commandsParser :: Parser Commands
@@ -84,6 +87,7 @@ commandsParser =
       <> command "gen-config" (info (pure GenConf) $ progDesc "generate example configuration")
       <> command "preview" (info (pure Preview) $ progDesc "generates preview.md into stdout")
       <> command "download" (info (Download <$> dlOptParser) $ progDesc "download images using IDS from a given PROVIDER")
+      <> command "metadata" (info (Metadata <$> metaOptParser) $ progDesc "act on stored metadata")
       <> command "query" (info (Query <$> qryOptParser) $ progDesc "retreive images with given TAGS")
 
 {- | # Download subcommand Options
@@ -108,3 +112,40 @@ qryOptParser :: Parser QueryOpts
 qryOptParser =
   QueryOpts
     <$> some (argument str (metavar "TAGS" <> help "list of tags to retreive images for"))
+
+data MetadataOpts = MetadataOpts
+  { action :: MetadataAction
+  , resolvedNames :: [String]
+  }
+
+metaOptParser :: Parser MetadataOpts
+metaOptParser =
+  MetadataOpts
+    <$> (mUpdateAction <|> mGetAction <|> mRemoveAction)
+    <*> some (argument str (metavar "RESOLVEDNAMES" <> help "list of resolvednames"))
+
+data MetadataAction
+  = Update
+  | Get
+  | Remove
+
+mUpdateAction :: Parser MetadataAction
+mUpdateAction =
+  flag' Update $
+    long "update"
+      <> short 'u'
+      <> help "update stored metadata"
+
+mGetAction :: Parser MetadataAction
+mGetAction =
+  flag' Get $
+    long "get"
+      <> short 'g'
+      <> help "retreive stored metadata"
+
+mRemoveAction :: Parser MetadataAction
+mRemoveAction =
+  flag' Remove $
+    long "remove"
+      <> short 'r'
+      <> help "remove stored metadata"

--- a/booru-cli/Cli/Utils/Build.hs
+++ b/booru-cli/Cli/Utils/Build.hs
@@ -44,14 +44,16 @@ validateCache srcs imgs = (validImgs, uncachedSrcs)
 getMetaData :: Map ProviderName (Identifier -> IO (Maybe Image)) -> Source -> IO [Image]
 getMetaData pmap Source{ids = idnfrs, provider = prv} = do
   let metaFetcher = findWithDefault (nullProvider prv) prv pmap
-      logAndFetch id' = do
-        let exid = extractId id'
-        putStrLn $ "Retriving metadata for: " ++ exid
-        img <- metaFetcher id'
-        when (isNothing img) $ putStrLn ("Unable to retreive: " ++ exid)
-        return img
-  metaList <- mapM logAndFetch idnfrs
+  metaList <- mapM (logAndFetch metaFetcher) idnfrs
   return $ catMaybes metaList
+
+logAndFetch :: (Identifier -> IO (Maybe Image)) -> Identifier -> IO (Maybe Image)
+logAndFetch fn id' = do
+    let exid = extractId id'
+    putStrLn $ "Retriving metadata for: " ++ exid
+    img <- fn id'
+    when (isNothing img) $ putStrLn ("Unable to retreive: " ++ exid)
+    return img
 
 {- | Downloads images into 'FilePath' when it does not contain the image
 - the function leveragtes 'Image.resolvedName' to identify existing files

--- a/booru-hs.cabal
+++ b/booru-hs.cabal
@@ -63,6 +63,7 @@ library booru-cli
     Cli.Commands.Build
     Cli.Commands.Download
     Cli.Commands.Generate
+    Cli.Commands.Metadata
     Cli.Commands.Preview
     Cli.Commands.Query
     Cli.Dispatcher

--- a/booru-hs.cabal
+++ b/booru-hs.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            booru-hs
-version:         1.0.0.0
+version:         1.0.0.1
 synopsis:        Extensible Auto-categorizing image library
 
 -- description:

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -40,7 +40,7 @@ in
   mkDerivation {
     inherit src;
     pname = "booru-hs";
-    version = "1.0.0.0";
+    version = "1.0.0.1";
     isLibrary = true;
     isExecutable = true;
     libraryHaskellDepends = [


### PR DESCRIPTION
added the ability to perform the following on stored metadata for a given list of resolved names:
- update metadata
- remove metadata
- query metadata